### PR TITLE
Fix coverage badge workflow by uploading coverage database

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -43,6 +43,7 @@ jobs:
       with:
         name: coverage-data
         path: |
+          .coverage
           coverage.xml
         retention-days: 1
 


### PR DESCRIPTION
The update-coverage-badge job was failing with "No data to report" because only coverage.xml was being uploaded, but `coverage report` needs the .coverage database file to generate reports.

Now uploading both .coverage and coverage.xml files so the badge update job can successfully extract coverage percentages.

Assisted-by: Cursor