### PR TITLE
Remove coverage generation from PR check workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -28,7 +28,4 @@ jobs:
       run: make test-unit
     
     - name: Run simple integration tests
-      run: make test-integration-simple
-    
-    - name: Generate coverage report
-      run: make coverage 
+      run: make test-integration-simple 


### PR DESCRIPTION
PR checks should only run tests for validation. Coverage generation is now handled by the separate coverage-badge.yml workflow that runs on pushes to main.

This should fix the failing test job in PR checks.

Assisted-by: Cursor