### PR TITLE
feat: support multiple repositories via --repo owner/repo

### DIFF
--- a/src/gh_pulls_summary/common.py
+++ b/src/gh_pulls_summary/common.py
@@ -73,6 +73,7 @@ class PullRequestData:
     rank: str = ""
     closed_issue_keys: set[str] = field(default_factory=set)
     jira_key: str | None = None
+    repo_name: str = ""
 
 
 @dataclass

--- a/src/gh_pulls_summary/main.py
+++ b/src/gh_pulls_summary/main.py
@@ -95,8 +95,8 @@ def parse_arguments():
     """
     Parses command-line arguments for the script.
     """
-    # Get default owner and repo from Git metadata
-    default_owner, default_repo = get_repo_and_owner_from_git()
+    # Get default owner from Git metadata
+    default_owner, _ = get_repo_and_owner_from_git()
 
     parser = argparse.ArgumentParser(
         description="Fetch and summarize GitHub pull requests."
@@ -104,12 +104,12 @@ def parse_arguments():
     parser.add_argument(
         "--owner",
         default=default_owner,
-        help="The owner of the repository (e.g., 'microsoft'). If not specified, defaults to the owner from the current directory's Git config.",
+        help="Default repository owner. Used when --repo values don't include 'owner/' prefix.",
     )
     parser.add_argument(
         "--repo",
-        default=default_repo,
-        help="The name of the repository (e.g., 'vscode'). If not specified, defaults to the repo name from the current directory's Git config.",
+        action="append",
+        help="Repository as 'owner/repo' or 'repo' (uses --owner). Can be specified multiple times. Defaults to current git remote.",
     )
     parser.add_argument(
         "--github-token",
@@ -231,6 +231,38 @@ def configure_logging(debug):
             logging.StreamHandler(sys.stderr)  # Log to stderr
         ],
     )
+
+
+def resolve_repos(args) -> list[tuple[str, str]]:
+    """Resolve --repo args into (owner, repo) tuples."""
+    default_owner, default_repo = get_repo_and_owner_from_git()
+
+    repos_arg = args.repo
+    if not repos_arg:
+        owner = args.owner or default_owner
+        repo = default_repo
+        if owner and repo:
+            return [(owner, repo)]
+        return []
+
+    result = []
+    seen = set()
+    for entry in repos_arg:
+        if "/" in entry:
+            owner, repo = entry.split("/", 1)
+        else:
+            owner = args.owner
+            repo = entry
+        if not owner or not repo:
+            raise ValidationError(
+                f"Cannot resolve repository '{entry}': owner is missing. "
+                f"Use 'owner/repo' format or provide --owner."
+            )
+        key = (owner, repo)
+        if key not in seen:
+            seen.add(key)
+            result.append(key)
+    return result
 
 
 def fetch_and_process_pull_requests(
@@ -666,23 +698,37 @@ def generate_markdown_output(args):
         jira_issue_patterns = [jira_issue_patterns]
     # else: already a list from argparse action="append"
 
-    # Fetch and process pull requests
-    pull_requests, jira_issues = fetch_and_process_pull_requests(
-        args.owner,
-        args.repo,
-        args.draft_filter,
-        file_include,
-        file_exclude,
-        args.pr_number,
-        args.url_from_pr_content,
-        jira_client=jira_client,
-        jira_issue_patterns=jira_issue_patterns,
-        jira_include=args.jira_include,
-        jira_metadata_row_pattern=args.jira_metadata_row_pattern,
-        jira_metadata_search_depth=args.jira_metadata_row_search_depth,
-        review_requested_for=args.review_requested_for,
-        github_token=github_token,
-    )
+    # Resolve repos and fetch PRs
+    repos = resolve_repos(args)
+    multi_repo = len(repos) > 1
+
+    if args.pr_number and multi_repo:
+        raise ValidationError("--pr-number cannot be used with multiple repositories.")
+
+    pull_requests = []
+    jira_issues = {}
+    for owner, repo in repos:
+        repo_prs, repo_jira = fetch_and_process_pull_requests(
+            owner,
+            repo,
+            args.draft_filter,
+            file_include,
+            file_exclude,
+            args.pr_number,
+            args.url_from_pr_content,
+            jira_client=jira_client,
+            jira_issue_patterns=jira_issue_patterns,
+            jira_include=args.jira_include,
+            jira_metadata_row_pattern=args.jira_metadata_row_pattern,
+            jira_metadata_search_depth=args.jira_metadata_row_search_depth,
+            review_requested_for=args.review_requested_for,
+            github_token=github_token,
+        )
+        if multi_repo:
+            for pr in repo_prs:
+                pr.repo_name = repo
+        pull_requests.extend(repo_prs)
+        jira_issues.update(repo_jira)
 
     # Add synthetic entries for jira-include issues that weren't found in any PRs
     if args.jira_include and jira_issues:
@@ -784,14 +830,18 @@ def main():
         print(f"ERROR: Failed to parse command line arguments. {e}", file=sys.stderr)
         sys.exit(1)
 
-    # Ensure owner and repo are provided
-    if not args.owner or not args.repo:
-        print("ERROR: Repository owner and name must be specified.", file=sys.stderr)
+    # Ensure at least one repo can be resolved
+    try:
+        repos = resolve_repos(args)
+    except ValidationError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+    if not repos:
+        print("ERROR: Repository must be specified.", file=sys.stderr)
         print(
-            "Either provide --owner and --repo arguments, or run the command",
+            "Use --repo owner/repo, or run from a Git repository with a GitHub remote.",
             file=sys.stderr,
         )
-        print("from within a Git repository with a GitHub remote.", file=sys.stderr)
         sys.exit(1)
 
     configure_logging(args.debug)

--- a/src/gh_pulls_summary/output.py
+++ b/src/gh_pulls_summary/output.py
@@ -102,7 +102,8 @@ def create_markdown_table_row(pr, url_column, rank_column, jira_issues=None):
         changes_text = ""
     else:
         # Regular PR entry
-        title_link = f"{pr.title} #[{pr.number}]({pr.url})"
+        prefix = f"{pr.repo_name}: " if pr.repo_name else ""
+        title_link = f"{prefix}{pr.title} #[{pr.number}]({pr.url})"
 
         author_link = f"[{pr.author_name}]({pr.author_url})" if pr.author_name else ""
         approvals_text = f"{pr.approvals} of {pr.reviews}" if pr.reviews > 0 else ""

--- a/tests/unit/test_argument_parsing.py
+++ b/tests/unit/test_argument_parsing.py
@@ -27,7 +27,7 @@ class TestArgumentParsing(unittest.TestCase):
     def test_parse_arguments_with_all_options(self):
         args = parse_arguments()
         self.assertEqual(args.owner, "owner")
-        self.assertEqual(args.repo, "repo")
+        self.assertEqual(args.repo, ["repo"])
         self.assertEqual(args.draft_filter, "no-drafts")
         self.assertTrue(args.debug)
 
@@ -35,7 +35,7 @@ class TestArgumentParsing(unittest.TestCase):
     def test_parse_arguments_with_required_options_only(self):
         args = parse_arguments()
         self.assertEqual(args.owner, "owner")
-        self.assertEqual(args.repo, "repo")
+        self.assertEqual(args.repo, ["repo"])
         self.assertIsNone(args.draft_filter)
         self.assertFalse(args.debug)
 
@@ -47,7 +47,7 @@ class TestArgumentParsing(unittest.TestCase):
     def test_parse_arguments_with_git_metadata(self, mock_get_repo_and_owner_from_git):
         args = parse_arguments()
         self.assertEqual(args.owner, "mock_owner")
-        self.assertEqual(args.repo, "mock_repo")
+        self.assertIsNone(args.repo)
 
     @patch(
         "gh_pulls_summary.main.get_repo_and_owner_from_git", return_value=(None, None)
@@ -80,7 +80,7 @@ class TestArgumentParsing(unittest.TestCase):
     def test_parse_arguments_with_url_from_pr_content(self):
         args = parse_arguments()
         self.assertEqual(args.owner, "owner")
-        self.assertEqual(args.repo, "repo")
+        self.assertEqual(args.repo, ["repo"])
         self.assertEqual(args.url_from_pr_content, "http://example.com")
 
     @patch(
@@ -100,7 +100,7 @@ class TestArgumentParsing(unittest.TestCase):
     def test_parse_arguments_with_jira_include(self):
         args = parse_arguments()
         self.assertEqual(args.owner, "owner")
-        self.assertEqual(args.repo, "repo")
+        self.assertEqual(args.repo, ["repo"])
         self.assertEqual(args.jira_include, ["PROJ-1234", "PROJ-5678"])
 
     @patch(
@@ -116,7 +116,7 @@ class TestArgumentParsing(unittest.TestCase):
     def test_parse_arguments_without_jira_include(self):
         args = parse_arguments()
         self.assertEqual(args.owner, "owner")
-        self.assertEqual(args.repo, "repo")
+        self.assertEqual(args.repo, ["repo"])
         self.assertIsNone(args.jira_include)
 
     @patch(
@@ -134,7 +134,7 @@ class TestArgumentParsing(unittest.TestCase):
     def test_parse_arguments_with_review_requested_for(self):
         args = parse_arguments()
         self.assertEqual(args.owner, "owner")
-        self.assertEqual(args.repo, "repo")
+        self.assertEqual(args.repo, ["repo"])
         self.assertEqual(args.review_requested_for, "testuser")
 
     @patch(
@@ -150,7 +150,7 @@ class TestArgumentParsing(unittest.TestCase):
     def test_parse_arguments_without_review_requested_for(self):
         args = parse_arguments()
         self.assertEqual(args.owner, "owner")
-        self.assertEqual(args.repo, "repo")
+        self.assertEqual(args.repo, ["repo"])
         self.assertIsNone(args.review_requested_for)
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -42,7 +42,7 @@ class TestMainFunction(unittest.TestCase):
 
         class Args:
             owner = "owner"
-            repo = "repo"
+            repo = ["repo"]
             draft_filter = None
             debug = False
             pr_number = None
@@ -111,7 +111,7 @@ class TestMainFunction(unittest.TestCase):
 
         class Args:
             owner = "owner"
-            repo = "repo"
+            repo = ["repo"]
             draft_filter = None
             debug = False
             pr_number = None
@@ -166,7 +166,7 @@ class TestMainFunction(unittest.TestCase):
 
         class Args:
             owner = "owner"
-            repo = "repo"
+            repo = ["repo"]
             draft_filter = None
             debug = False
             pr_number = None
@@ -234,7 +234,7 @@ class TestMainFunction(unittest.TestCase):
 
         class Args:
             owner = "owner"
-            repo = "repo"
+            repo = ["repo"]
             draft_filter = None
             debug = False
             pr_number = None
@@ -387,7 +387,7 @@ class TestMainFunction(unittest.TestCase):
 
         # Verify that error message was printed to stderr
         mock_print.assert_any_call(
-            "ERROR: Repository owner and name must be specified.", file=sys.stderr
+            "ERROR: Repository must be specified.", file=sys.stderr
         )
 
     @patch("gh_pulls_summary.main.generate_markdown_output")
@@ -854,24 +854,19 @@ class TestHelperFunctions(unittest.TestCase):
 
         self.assertIn("Pull request #99 not found", str(ctx.exception))
 
+    @patch(
+        "gh_pulls_summary.main.get_repo_and_owner_from_git",
+        return_value=(None, None),
+    )
     @patch("gh_pulls_summary.main.sys.exit")
-    def test_main_failure_without_owner_and_repo(self, mock_exit):
+    def test_main_failure_without_owner_and_repo(self, mock_exit, mock_git):
         """Test main function exits when owner and repo are not provided."""
-        # Make sys.exit actually raise SystemExit to stop execution
         mock_exit.side_effect = SystemExit(1)
 
         with patch("gh_pulls_summary.main.parse_arguments") as mock_parse:
             mock_args = Mock()
             mock_args.owner = None
             mock_args.repo = None
-            # Add the required attributes that the main function checks
-            mock_args.file_include = None
-            mock_args.file_exclude = None
-            mock_args.pr_number = None
-            mock_args.url_from_pr_content = None
-            mock_args.draft_filter = None
-            mock_args.sort_column = "date"
-            mock_args.column_title = None
             mock_args.debug = False
             mock_args.output_markdown = None
             mock_parse.return_value = mock_args
@@ -879,7 +874,6 @@ class TestHelperFunctions(unittest.TestCase):
             with self.assertRaises(SystemExit) as ctx:
                 main()
 
-            # Verify that sys.exit was called with code 1
             self.assertEqual(ctx.exception.code, 1)
             mock_exit.assert_called_with(1)
 

--- a/tests/unit/test_processing_logic.py
+++ b/tests/unit/test_processing_logic.py
@@ -222,7 +222,7 @@ class TestGenerateMarkdownOutput(unittest.TestCase):
         # Mock arguments
         args = MagicMock(
             owner="owner",
-            repo="repo",
+            repo=["repo"],
             draft_filter=None,
             file_include=None,
             file_exclude=None,
@@ -289,7 +289,7 @@ class TestGenerateMarkdownOutput(unittest.TestCase):
     def test_generate_markdown_output_with_custom_titles(self, mock_fetch):
         class Args:
             owner = "owner"
-            repo = "repo"
+            repo = ["repo"]
             draft_filter = None
             debug = False
             pr_number = None
@@ -342,7 +342,7 @@ class TestGenerateMarkdownOutput(unittest.TestCase):
     def test_generate_markdown_output_sort_by_title(self, mock_fetch):
         class Args:
             owner = "owner"
-            repo = "repo"
+            repo = ["repo"]
             draft_filter = None
             debug = False
             pr_number = None


### PR DESCRIPTION
--repo now accepts owner/repo format and can be specified multiple
times to combine PRs from different repos into a single table.
When multiple repos are queried, repo name is prepended to PR
titles in the output.

Assisted-by: Claude Code (Claude Opus 4.6)
